### PR TITLE
An XXE demo with only a few pre-defined XML documents to parse

### DIFF
--- a/site/xml/xxe/config/config.ini
+++ b/site/xml/xxe/config/config.ini
@@ -1,0 +1,2 @@
+[admin]
+password=hunter2

--- a/site/xml/xxe/file.txt
+++ b/site/xml/xxe/file.txt
@@ -1,0 +1,2 @@
+Hello darkness, my old friend
+I've come to talk with you again

--- a/site/xml/xxe/index.php
+++ b/site/xml/xxe/index.php
@@ -1,0 +1,104 @@
+<?php
+$xml1 = <<< 'EOT'
+<!DOCTYPE root [
+  <!ENTITY foo SYSTEM "file.txt">
+]>
+<xml>&foo;</xml>
+EOT;
+
+$xml2 = <<< 'EOT'
+<!DOCTYPE root [
+  <!ENTITY foo SYSTEM "config/config.ini">
+]>
+<xml>&foo;</xml>
+EOT;
+
+$xml3 = <<< 'EOT'
+<!DOCTYPE root [
+  <!ENTITY foo SYSTEM "php://filter/read=convert.base64-encode/resource=index.php">
+]>
+<xml>&foo;</xml>
+EOT;
+
+function removeWhitespace(string $input): string
+{
+	return preg_replace("/[\r\n]+|^\s+/m", '', trim($input));
+}
+
+if (isset($_POST['xml']) && is_string($_POST['xml'])) {
+	$originalInput = $_POST['xml'];
+}
+$substitute = $_POST['substitute'] ?? '' === 'yes';
+?>
+<head>
+<title>XML External Entity Injection (XXE) demo</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+body { max-width: 820px; margin: 1em auto; padding: 1em; line-height: 1.5; }
+pre { white-space: pre-wrap; word-wrap: break-word; word-break: break-word; background-color: #EEE; padding: 1em; }
+textarea { width: 100%; }
+.copy { cursor: pointer; }
+</style>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+	document.querySelectorAll('.copy').forEach(function (element) {
+		element.addEventListener('click', function () {
+			document.getElementById('input').value = this.innerText;
+		});
+	})
+});
+</script>
+</head>
+<body>
+<h1>XXE (XML External Entity Injection) demo</h1>
+<strong>Try parsing one of the following XMLs</strong>, click to copy the code to the input area below (the demo won't parse any other XML <em>because security</em>)
+<p><em>To get a contents of <code>file.txt</code>:</em></p><pre class="copy"><?= htmlspecialchars($xml1); ?></pre>
+<p><em>To get a contents of <code>config/config.ini</code>:</em></p><pre class="copy"><?= htmlspecialchars($xml2); ?></pre>
+<p><em>To get a contents of this PHP file:</em></p><pre class="copy"><?= htmlspecialchars($xml3); ?></pre>
+
+<h2>Parse XML</h2>
+<form action="" method="post">
+	<p><textarea id="input" wrap="off" rows="10" name="xml"><?= htmlspecialchars($originalInput ?? ''); ?></textarea></p>
+	<p>
+		<label><input type="checkbox" name="substitute" value="yes"<?= $substitute ? ' checked' : '';?>> Substitute entities?</label>
+		<input type="submit" value="Parse">
+	</p>
+</form>
+<p>
+	Starting with PHP 8.0, the minimum <a href="https://www.php.net/manual/en/migration80.other-changes.php#migration80.other-changes.extensions.libxml">required libxml version is 2.9.0</a>
+	which means that external entity loading is now guaranteed to be disabled by default, and no extra steps need to be taken to protect against XXE attacks. Previously, you had to
+	call <a href="https://www.php.net/manual/en/function.libxml-disable-entity-loader"><code>libxml_disable_entity_loader()</code></a> to make sure the loader is disabled.
+	When checked, the checkbox above simulates the older defaults where entities were substituted, demostrating the XXE (XML External Entity Injection) attack.
+</p>
+
+<?php
+if ($originalInput ?? false) {
+	$input = removeWhitespace($originalInput);
+	foreach ([$xml1, $xml2, $xml3] as $xml) {
+		if ($input === removeWhitespace($xml)) {
+			$allowed = true;
+		}
+	}
+	echo '<h2>The result</h2>';
+	if ($allowed ?? false) {
+		libxml_use_internal_errors(true);
+		// LIBXML_NOENT is not a good idea but is needed to make the XXE work on newer PHP versions; remember this is a demo, not a pruduction app
+		$options = $substitute ? LIBXML_NOENT : 0;
+		$element = simplexml_load_string($_POST['xml'], options: $options);
+		if ($element === false) {
+			echo '<p><strong>Something went wrong</strong></p>';
+			foreach (libxml_get_errors() as $error) {
+				echo "{$error->message} on line {$error->line}<br>";
+			}
+		} else {
+			echo '<p><strong>The element</strong>:</p><pre>' . (htmlspecialchars((string)$element) ?: '<em>none</em>') . '</pre>';
+			echo '<p><strong>The eventual XML as seen by the parser</strong>:</p><pre>' . htmlspecialchars($element->asXML()) . '</pre>';
+		}
+	} else {
+		echo 'The submitted XML is not allowed, try again';
+	}
+}
+?>
+<hr>
+<em>By Michal Špaček <a href="https://www.michalspaacek.com/">michalspacek.com</a>, <a href="https://twitter.com/spazef0rze">@spazef0rze</a>, <a href="https://github.com/spaze/exploited.cz/tree/main/site/xml/xxe">source</a></em>
+</body>


### PR DESCRIPTION
This is a security measure to cripple the attack. There's nothing interesting on the server but still...

Upgrade your PHPs because starting with PHP 8.0, the attack has a built-in mitigation: [no entity substitution by default](https://www.php.net/manual/en/migration80.other-changes.php#migration80.other-changes.extensions.libxml).